### PR TITLE
Switch macOS CI to ARM arch

### DIFF
--- a/.cirrus.yaml
+++ b/.cirrus.yaml
@@ -105,7 +105,7 @@ test_task:
       <<: *unix_bundle_cache
 
     - macos_instance:
-        image: big-sur-base
+        image: ghcr.io/cirruslabs/macos-ventura-base:latest
 
       env:
         PATH: "/usr/local/opt/ruby/bin:$PATH"


### PR DESCRIPTION
x86 is no longer supported by Cirrus CI.
Let's move on.